### PR TITLE
Проверка возраста

### DIFF
--- a/app/addons/age_restriction/Tygh/Enum/Addons/AgeRestriction/AgeRestrictionTypes.php
+++ b/app/addons/age_restriction/Tygh/Enum/Addons/AgeRestriction/AgeRestrictionTypes.php
@@ -1,0 +1,30 @@
+<?php
+
+/***************************************************************************
+ *                                                                          *
+ *   (c) 2004 Vladimir V. Kalynyak, Alexey V. Vinokurov, Ilya M. Shalnev    *
+ *                                                                          *
+ * This  is  commercial  software,  only  users  who have purchased a valid *
+ * license  and  accept  to the terms of the  License Agreement can install *
+ * and use this program.                                                    *
+ *                                                                          *
+ ****************************************************************************
+ * PLEASE READ THE FULL TEXT  OF THE SOFTWARE  LICENSE   AGREEMENT  IN  THE *
+ * "copyright.txt" FILE PROVIDED WITH THIS DISTRIBUTION PACKAGE.            *
+ ****************************************************************************/
+
+namespace Tygh\Enum\Addons\AgeRestriction;
+
+/**
+ * AgeRestrictionTypes contains types for allowing or denying access to the website
+ *
+ * @package Tygh\Enum
+ */
+class AgeRestrictionTypes
+{
+    public const ALLOWED = 'A';
+
+    public const DENIED = 'D';
+
+    public const NOT_SET = 'N';
+}

--- a/app/addons/age_restriction/addon.xml
+++ b/app/addons/age_restriction/addon.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<addon scheme="3.0">
+    <id>age_restriction</id>
+    <version>1.0</version>
+    <priority>5000</priority>
+    <position>0</position>
+    <status>active</status>
+    <default_language>ru</default_language>
+    <settings edition_type="ROOT,ULT:VENDOR">
+        <sections>
+            <section id="general">
+                <items>
+                    <item id="min_age">
+                        <type>input</type>
+                        <default_value>18</default_value>
+                    </item>
+                </items>
+            </section>
+        </sections>
+    </settings>
+</addon>

--- a/app/addons/age_restriction/config.php
+++ b/app/addons/age_restriction/config.php
@@ -1,0 +1,21 @@
+<?php
+
+/***************************************************************************
+ *                                                                          *
+ *   (c) 2004 Vladimir V. Kalynyak, Alexey V. Vinokurov, Ilya M. Shalnev    *
+ *                                                                          *
+ * This  is  commercial  software,  only  users  who have purchased a valid *
+ * license  and  accept  to the terms of the  License Agreement can install *
+ * and use this program.                                                    *
+ *                                                                          *
+ ****************************************************************************
+ * PLEASE READ THE FULL TEXT  OF THE SOFTWARE  LICENSE   AGREEMENT  IN  THE *
+ * "copyright.txt" FILE PROVIDED WITH THIS DISTRIBUTION PACKAGE.            *
+ ****************************************************************************/
+
+if (!defined('BOOTSTRAP')) {
+    die('Access denied');
+}
+
+//Constant for cookie name
+fn_define('AGE_RESTRICTION_IS_LEGIT', 'is_legit');

--- a/app/addons/age_restriction/controllers/frontend/age_restriction.php
+++ b/app/addons/age_restriction/controllers/frontend/age_restriction.php
@@ -1,0 +1,34 @@
+<?php
+
+/***************************************************************************
+ *                                                                          *
+ *   (c) 2004 Vladimir V. Kalynyak, Alexey V. Vinokurov, Ilya M. Shalnev    *
+ *                                                                          *
+ * This  is  commercial  software,  only  users  who have purchased a valid *
+ * license  and  accept  to the terms of the  License Agreement can install *
+ * and use this program.                                                    *
+ *                                                                          *
+ ****************************************************************************
+ * PLEASE READ THE FULL TEXT  OF THE SOFTWARE  LICENSE   AGREEMENT  IN  THE *
+ * "copyright.txt" FILE PROVIDED WITH THIS DISTRIBUTION PACKAGE.            *
+ ****************************************************************************/
+
+use Tygh\Enum\Addons\AgeRestriction\AgeRestrictionTypes;
+
+if (!defined('BOOTSTRAP')) {
+    die('Access denied');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($mode === 'verify') {
+        $is_legit = fn_get_cookie(AGE_RESTRICTION_IS_LEGIT);
+        $is_cookie_set = $is_legit === AgeRestrictionTypes::ALLOWED || $is_legit === AgeRestrictionTypes::DENIED;
+        if ($_REQUEST['age'] && !$is_cookie_set) {
+            $is_age_valid = fn_age_restriction_compare($_REQUEST['age']);
+            fn_set_cookie(AGE_RESTRICTION_IS_LEGIT, $is_age_valid);
+        }
+
+        //Redirect to redirect_url if exists
+        return [CONTROLLER_STATUS_REDIRECT, $_REQUEST['redirect_url'] ?? ''];
+    }
+}

--- a/app/addons/age_restriction/controllers/frontend/age_restriction.php
+++ b/app/addons/age_restriction/controllers/frontend/age_restriction.php
@@ -14,6 +14,7 @@
  ****************************************************************************/
 
 use Tygh\Enum\Addons\AgeRestriction\AgeRestrictionTypes;
+use Tygh\Enum\NotificationSeverity;
 
 if (!defined('BOOTSTRAP')) {
     die('Access denied');
@@ -23,10 +24,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($mode === 'verify') {
         $is_legit = fn_get_cookie(AGE_RESTRICTION_IS_LEGIT);
         $is_cookie_set = $is_legit === AgeRestrictionTypes::ALLOWED || $is_legit === AgeRestrictionTypes::DENIED;
-        if ($_REQUEST['age'] && !$is_cookie_set) {
-            $is_age_valid = fn_age_restriction_compare($_REQUEST['age']);
-            fn_set_cookie(AGE_RESTRICTION_IS_LEGIT, $is_age_valid);
+
+        if (empty($_REQUEST['age']) || $is_cookie_set) {
+            return [CONTROLLER_STATUS_OK];
         }
+
+        $is_age_valid = fn_age_restriction_compare($_REQUEST['age']);
+
+        if ($is_age_valid === false) {
+            fn_set_notification(
+                NotificationSeverity::ERROR,
+                __('error'),
+                __('age_restriction_wrong_date')
+            );
+            return [CONTROLLER_STATUS_OK];
+        }
+
+        fn_set_cookie(AGE_RESTRICTION_IS_LEGIT, $is_age_valid);
 
         //Redirect to redirect_url if exists
         return [CONTROLLER_STATUS_REDIRECT, $_REQUEST['redirect_url'] ?? ''];

--- a/app/addons/age_restriction/controllers/frontend/init.post.php
+++ b/app/addons/age_restriction/controllers/frontend/init.post.php
@@ -22,10 +22,6 @@ if (!defined('BOOTSTRAP')) {
 
 $auth = Tygh::$app['session']['auth'];
 
-if ($auth['user_id'] !== 0) {
-    return;
-}
-
 $is_legit = fn_get_cookie(AGE_RESTRICTION_IS_LEGIT);
 $min_age = '';
 

--- a/app/addons/age_restriction/controllers/frontend/init.post.php
+++ b/app/addons/age_restriction/controllers/frontend/init.post.php
@@ -1,0 +1,50 @@
+<?php
+
+/***************************************************************************
+ *                                                                          *
+ *   (c) 2004 Vladimir V. Kalynyak, Alexey V. Vinokurov, Ilya M. Shalnev    *
+ *                                                                          *
+ * This  is  commercial  software,  only  users  who have purchased a valid *
+ * license  and  accept  to the terms of the  License Agreement can install *
+ * and use this program.                                                    *
+ *                                                                          *
+ ****************************************************************************
+ * PLEASE READ THE FULL TEXT  OF THE SOFTWARE  LICENSE   AGREEMENT  IN  THE *
+ * "copyright.txt" FILE PROVIDED WITH THIS DISTRIBUTION PACKAGE.            *
+ ****************************************************************************/
+
+use Tygh\Enum\Addons\AgeRestriction\AgeRestrictionTypes;
+use Tygh\Registry;
+
+if (!defined('BOOTSTRAP')) {
+    die('Access denied');
+}
+
+$auth = Tygh::$app['session']['auth'];
+
+if ($auth['user_id'] !== 0) {
+    return;
+}
+
+$is_legit = fn_get_cookie(AGE_RESTRICTION_IS_LEGIT);
+$min_age = '';
+
+if (empty($is_legit)) {
+    $is_legit = AgeRestrictionTypes::NOT_SET;
+}
+
+switch ($is_legit) {
+    case AgeRestrictionTypes::ALLOWED:
+        return;
+    case AgeRestrictionTypes::DENIED:
+        fn_age_restriction_redirect_home_page();
+        break;
+    case AgeRestrictionTypes::NOT_SET:
+        $min_age = Registry::get('addons.age_restriction.min_age');
+        break;
+}
+
+Tygh::$app['view']->assign([
+    'is_legit' => $is_legit,
+    'min_age' => $min_age
+]);

--- a/app/addons/age_restriction/func.php
+++ b/app/addons/age_restriction/func.php
@@ -1,0 +1,57 @@
+<?php
+
+/***************************************************************************
+ *                                                                          *
+ *   (c) 2004 Vladimir V. Kalynyak, Alexey V. Vinokurov, Ilya M. Shalnev    *
+ *                                                                          *
+ * This  is  commercial  software,  only  users  who have purchased a valid *
+ * license  and  accept  to the terms of the  License Agreement can install *
+ * and use this program.                                                    *
+ *                                                                          *
+ ****************************************************************************
+ * PLEASE READ THE FULL TEXT  OF THE SOFTWARE  LICENSE   AGREEMENT  IN  THE *
+ * "copyright.txt" FILE PROVIDED WITH THIS DISTRIBUTION PACKAGE.            *
+ ****************************************************************************/
+
+use Tygh\Registry;
+use Tygh\Enum\Addons\AgeRestriction\AgeRestrictionTypes;
+
+if (!defined('BOOTSTRAP')) {
+    die('Access denied');
+}
+
+/**
+ * Compare allowed date with passed date and return AgeRestrictionType
+ *
+ * @param string $date Age from datepicker
+ *
+ * @return string|false returns false if date is invalid otherwise ALLOWED or DENIED string
+ */
+function fn_age_restriction_compare($date)
+{
+    $min_age = Registry::get('addons.age_restriction.min_age');
+    $date = strtotime($date);
+    if (empty($date)) {
+        return false;
+    }
+    $allowedYearFrom = (int) date('Y') - $min_age;
+    $specifiedYear = (int) date('Y', $date);
+    return $specifiedYear <= $allowedYearFrom ?
+        AgeRestrictionTypes::ALLOWED :
+        AgeRestrictionTypes::DENIED;
+}
+
+/**
+ * Redirect to home page if current page is not home page
+ *
+ * @return void
+ */
+function fn_age_restriction_redirect_home_page()
+{
+    $current_url = Registry::get('config.current_url');
+    $home_url = fn_url();
+    if (!fn_compare_dispatch($current_url, $home_url)) {
+        fn_redirect($home_url);
+        exit;
+    }
+}

--- a/app/addons/age_restriction/init.php
+++ b/app/addons/age_restriction/init.php
@@ -1,0 +1,18 @@
+<?php
+
+/***************************************************************************
+ *                                                                          *
+ *   (c) 2004 Vladimir V. Kalynyak, Alexey V. Vinokurov, Ilya M. Shalnev    *
+ *                                                                          *
+ * This  is  commercial  software,  only  users  who have purchased a valid *
+ * license  and  accept  to the terms of the  License Agreement can install *
+ * and use this program.                                                    *
+ *                                                                          *
+ ****************************************************************************
+ * PLEASE READ THE FULL TEXT  OF THE SOFTWARE  LICENSE   AGREEMENT  IN  THE *
+ * "copyright.txt" FILE PROVIDED WITH THIS DISTRIBUTION PACKAGE.            *
+ ****************************************************************************/
+
+if (!defined('BOOTSTRAP')) {
+    die('Access denied');
+}

--- a/design/themes/responsive/css/addons/age_restriction/style.less
+++ b/design/themes/responsive/css/addons/age_restriction/style.less
@@ -1,0 +1,31 @@
+/* ==========================================================================
+Age restriction
+========================================================================== */
+.ui-dialog[aria-describedby=confirm-age-dialog] {
+    .unfocus-hack {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+
+    .ui-dialog-titlebar {
+        .ui-dialog-titlebar-close {
+            display: none;
+        }
+    }
+}
+
+.ui-dialog[aria-describedby=access-restricted-by-age] {
+    #access-restricted-by-age {
+        min-height: unset !important;
+        h2 {
+            text-align: center;
+        }
+    }
+
+    .ui-dialog-titlebar {
+        display: none !important;
+    }
+}
+/* Age restriction */

--- a/design/themes/responsive/templates/addons/age_restriction/hooks/index/content.pre.tpl
+++ b/design/themes/responsive/templates/addons/age_restriction/hooks/index/content.pre.tpl
@@ -1,0 +1,9 @@
+{if $is_legit === "Addons\\AgeRestriction\\AgeRestrictionTypes::DENIED"|enum}
+	{include 
+    "addons/age_restriction/views/age_restriction/components/restrict_access.tpl"
+    }
+{elseif $is_legit === "Addons\\AgeRestriction\\AgeRestrictionTypes::NOT_SET"|enum}
+	{include 
+    "addons/age_restriction/views/age_restriction/components/confirm_age.tpl"
+    }
+{/if}

--- a/design/themes/responsive/templates/addons/age_restriction/hooks/index/styles.pre.tpl
+++ b/design/themes/responsive/templates/addons/age_restriction/hooks/index/styles.pre.tpl
@@ -1,0 +1,1 @@
+{style src="addons/age_restriction/style.less"}

--- a/design/themes/responsive/templates/addons/age_restriction/views/age_restriction/components/confirm_age.tpl
+++ b/design/themes/responsive/templates/addons/age_restriction/views/age_restriction/components/confirm_age.tpl
@@ -1,0 +1,41 @@
+<div 
+    class="cm-dialog-auto-open cm-dialog-auto-size" 
+    id="confirm-age-dialog"
+    title="{__("age_restriction_confirm_age")}" 
+>
+	<form action="{""|fn_url}"
+	 method="post" 
+	 name="confirm_age_form">
+		<input type="hidden" name="redirect_url" value="{$config.current_url}" />
+		<input 
+			class="unfocus-hack cm-external-focus" 
+			data-ca-external-focus-id="unfocus-hack"
+			type="text" 
+		>
+
+		<div class="ty-control-group">
+    	    <label 
+            class="ty-control-group__title cm-required" 
+            for="elm_confirm_age">{__("age_restriction_birthday")}</label>
+			{include 
+				"common/calendar.tpl"
+                date_id="elm_confirm_age" 
+                date_name="age" 
+                date_val=$smarty.const.TIME 
+			}
+            <p>
+                <small>{__("age_restriction_min_age_to_access")}: {$min_age}</small>
+            </p>
+		</div>
+
+		<div class="buttons-container">			
+    		{include
+				"buttons/button.tpl" 
+				but_name="dispatch[age_restriction.verify]" 
+				but_text=__("submit") 
+				but_role="submit" 
+				but_meta="ty-btn__primary ty-btn__big ty-btn"
+            }
+		</div>
+	</form>
+</div>

--- a/design/themes/responsive/templates/addons/age_restriction/views/age_restriction/components/restrict_access.tpl
+++ b/design/themes/responsive/templates/addons/age_restriction/views/age_restriction/components/restrict_access.tpl
@@ -1,0 +1,6 @@
+<div 
+    class="cm-dialog-auto-open cm-dialog-auto-size" 
+    id="access-restricted-by-age"
+>
+	<h2>{__("age_restriction_access_restricted_by_age")}</h2>
+</div>

--- a/var/langs/en/addons/age_restriction.po
+++ b/var/langs/en/addons/age_restriction.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr "Project-Id-Version: tygh\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: English\n"
+"Language: en_US\n"
+
+msgctxt "Addons::name::age_restriction"
+msgid "Age restriction"
+msgstr "Age restriction (additional task)"
+
+msgctxt "Addons::description::age_restriction"
+msgid "You can restrict access by age for visitors"
+msgstr "You can restrict access by age for visitors"
+
+msgctxt "Languages::age_restriction_confirm_age"
+msgid "Confirm your age"
+msgstr "Confirm your age"
+
+msgctxt "Languages::age_restriction_birthday"
+msgid "Your birthday"
+msgstr "Your birthday"
+
+msgctxt "Languages::age_restriction_min_age_to_access"
+msgid "Minimum age to access"
+msgstr "Minimum age to access"
+
+msgctxt "Languages::age_restriction_access_restricted_by_age"
+msgid "Access to the site is closed because the age is not verified"
+msgstr "Access to the site is closed because the age is not verified"
+
+msgctxt "SettingsOptions::age_restriction::min_age"
+msgid "Minimum age"
+msgstr "Minimum age"

--- a/var/langs/en/addons/age_restriction.po
+++ b/var/langs/en/addons/age_restriction.po
@@ -28,6 +28,10 @@ msgctxt "Languages::age_restriction_access_restricted_by_age"
 msgid "Access to the site is closed because the age is not verified"
 msgstr "Access to the site is closed because the age is not verified"
 
+msgctxt "Languages::age_restriction_wrong_date"
+msgid "You entered wrong date"
+msgstr "You entered wrong date"
+
 msgctxt "SettingsOptions::age_restriction::min_age"
 msgid "Minimum age"
 msgstr "Minimum age"

--- a/var/langs/ru/addons/age_restriction.po
+++ b/var/langs/ru/addons/age_restriction.po
@@ -28,6 +28,10 @@ msgctxt "Languages::age_restriction_access_restricted_by_age"
 msgid "Access to the site is closed because the age is not verified"
 msgstr "Доступ на сайт закрыт, так как возраст не подтвержден"
 
+msgctxt "Languages::age_restriction_wrong_date"
+msgid "You entered wrong date"
+msgstr "Вы ввели некорректную дату"
+
 msgctxt "SettingsOptions::age_restriction::min_age"
 msgid "Minimum age"
 msgstr "Минимальный возраст"

--- a/var/langs/ru/addons/age_restriction.po
+++ b/var/langs/ru/addons/age_restriction.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr "Project-Id-Version: tygh\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Russian\n"
+"Language: ru_RU\n"
+
+msgctxt "Addons::name::age_restriction"
+msgid "Age restriction"
+msgstr "Ограничение возраста (Доп задание)"
+
+msgctxt "Addons::description::age_restriction"
+msgid "You can restrict access by age for visitors"
+msgstr "Вы можете ограничить доступ по возрасту для посетителей"
+
+msgctxt "Languages::age_restriction_confirm_age"
+msgid "Confirm your age"
+msgstr "Подтвердите свой возраст"
+
+msgctxt "Languages::age_restriction_birthday"
+msgid "Your birthday"
+msgstr "Ваш день рождения"
+
+msgctxt "Languages::age_restriction_min_age_to_access"
+msgid "Minimum age to access"
+msgstr "Минимальный возраст для доступа"
+
+msgctxt "Languages::age_restriction_access_restricted_by_age"
+msgid "Access to the site is closed because the age is not verified"
+msgstr "Доступ на сайт закрыт, так как возраст не подтвержден"
+
+msgctxt "SettingsOptions::age_restriction::min_age"
+msgid "Minimum age"
+msgstr "Минимальный возраст"

--- a/var/themes_repository/responsive/css/addons/age_restriction/style.less
+++ b/var/themes_repository/responsive/css/addons/age_restriction/style.less
@@ -1,0 +1,31 @@
+/* ==========================================================================
+Age restriction
+========================================================================== */
+.ui-dialog[aria-describedby=confirm-age-dialog] {
+    .unfocus-hack {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+
+    .ui-dialog-titlebar {
+        .ui-dialog-titlebar-close {
+            display: none;
+        }
+    }
+}
+
+.ui-dialog[aria-describedby=access-restricted-by-age] {
+    #access-restricted-by-age {
+        min-height: unset !important;
+        h2 {
+            text-align: center;
+        }
+    }
+
+    .ui-dialog-titlebar {
+        display: none !important;
+    }
+}
+/* Age restriction */

--- a/var/themes_repository/responsive/templates/addons/age_restriction/hooks/index/content.pre.tpl
+++ b/var/themes_repository/responsive/templates/addons/age_restriction/hooks/index/content.pre.tpl
@@ -1,0 +1,9 @@
+{if $is_legit === "Addons\\AgeRestriction\\AgeRestrictionTypes::DENIED"|enum}
+	{include 
+    "addons/age_restriction/views/age_restriction/components/restrict_access.tpl"
+    }
+{elseif $is_legit === "Addons\\AgeRestriction\\AgeRestrictionTypes::NOT_SET"|enum}
+	{include 
+    "addons/age_restriction/views/age_restriction/components/confirm_age.tpl"
+    }
+{/if}

--- a/var/themes_repository/responsive/templates/addons/age_restriction/hooks/index/styles.pre.tpl
+++ b/var/themes_repository/responsive/templates/addons/age_restriction/hooks/index/styles.pre.tpl
@@ -1,0 +1,1 @@
+{style src="addons/age_restriction/style.less"}

--- a/var/themes_repository/responsive/templates/addons/age_restriction/views/age_restriction/components/confirm_age.tpl
+++ b/var/themes_repository/responsive/templates/addons/age_restriction/views/age_restriction/components/confirm_age.tpl
@@ -1,0 +1,41 @@
+<div 
+    class="cm-dialog-auto-open cm-dialog-auto-size" 
+    id="confirm-age-dialog"
+    title="{__("age_restriction_confirm_age")}" 
+>
+	<form action="{""|fn_url}"
+	 method="post" 
+	 name="confirm_age_form">
+		<input type="hidden" name="redirect_url" value="{$config.current_url}" />
+		<input 
+			class="unfocus-hack cm-external-focus" 
+			data-ca-external-focus-id="unfocus-hack"
+			type="text" 
+		>
+
+		<div class="ty-control-group">
+    	    <label 
+            class="ty-control-group__title cm-required" 
+            for="elm_confirm_age">{__("age_restriction_birthday")}</label>
+			{include 
+				"common/calendar.tpl"
+                date_id="elm_confirm_age" 
+                date_name="age" 
+                date_val=$smarty.const.TIME 
+			}
+            <p>
+                <small>{__("age_restriction_min_age_to_access")}: {$min_age}</small>
+            </p>
+		</div>
+
+		<div class="buttons-container">			
+    		{include
+				"buttons/button.tpl" 
+				but_name="dispatch[age_restriction.verify]" 
+				but_text=__("submit") 
+				but_role="submit" 
+				but_meta="ty-btn__primary ty-btn__big ty-btn"
+            }
+		</div>
+	</form>
+</div>

--- a/var/themes_repository/responsive/templates/addons/age_restriction/views/age_restriction/components/restrict_access.tpl
+++ b/var/themes_repository/responsive/templates/addons/age_restriction/views/age_restriction/components/restrict_access.tpl
@@ -1,0 +1,6 @@
+<div 
+    class="cm-dialog-auto-open cm-dialog-auto-size" 
+    id="access-restricted-by-age"
+>
+	<h2>{__("age_restriction_access_restricted_by_age")}</h2>
+</div>


### PR DESCRIPTION
Для того, чтобы ограничить доступ к содержимому сайта лиц не достигших 18 лет необходимо реализовать всплывающее окно на черном фоне, на котором будет предлагаться посетителю ввести дату своего рождения и подтвердить возраст. Всплывающее окно должно быть на любой странице сайта.

В случае если посетитель ввел дату рождения и его возраст оказался больше 18 лет, всплывающее окно удаляется, записывается кука о том, что возраст проверен. Далее на протяжении всей сессии всплывающее окно проверки возраста не должно появляться.

Если пользователю меньше 18 лет, записывается кука о том, что возраст не подтвержден. Содержимое всплывающего окна должно изменится и содержать информацию о том, что доступ на сайт закрыт так как возраст не подтвержден. При перезагрузке страницы окно с информацией о неподтвержденном возрасте должно также всплывать блокируя тем самым доступ к контенту на любой странице.

Проверка введенных данных должна производится на стороне PHP.